### PR TITLE
Compatibility with xtensor as CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ message(STATUS "Building pyxtensor v${PYXTENSOR_VERSION}")
 # Set target
 # ==========
 
-find_package(xtensor REQUIRED)
+if(NOT TARGET xtensor)
+    find_package(xtensor REQUIRED)
+endif()
 
 add_library(pyxtensor INTERFACE)
 


### PR DESCRIPTION
Hi,  

This patch is for supporting the setup in which one would include `xtensor` using `add_subdirectory` (for example, if one uses `pyxtensor` as a git submodule).